### PR TITLE
Displaying mobbr button in question lists

### DIFF
--- a/qa-mobbr-admin.php
+++ b/qa-mobbr-admin.php
@@ -13,6 +13,8 @@
                 return 1;
             elseif ($option=='mobbr_support_currency')
                 return 'EUR';
+            elseif ($option=='mobbr_support_show_button_in_lists')
+                return false;
             elseif ($option=='mobbr_support_language')
                 return 'EN';
             elseif ($option=='mobbr_support_buttontype')
@@ -52,6 +54,7 @@
                 qa_opt('mobbr_support_language', qa_post_text('mobbr_support_language_field'));
                 qa_opt('mobbr_support_badgetype', qa_post_text('mobbr_support_badgetype_field'));
                 qa_opt('mobbr_support_currency', qa_post_text('mobbr_support_currency_field'));
+                qa_opt('mobbr_support_show_button_in_lists', (bool) qa_post_text('mobbr_support_show_button_in_lists_field'));
                 qa_opt('mobbr_support_buttontype', qa_post_text('mobbr_support_buttontype_field'));
                 qa_opt('mobbr_support_title_link', qa_post_text('mobbr_support_title_link_field'));
                 qa_opt('mobbr_support_title', qa_post_text('mobbr_support_title_field'));
@@ -98,6 +101,12 @@
                         'value' => qa_mobbr::$currencies[qa_opt('mobbr_support_currency')],
                         'options' => qa_mobbr::$currencies,
                         'tags' => 'name="mobbr_support_currency_field"',
+                    ),
+                    array(
+                        'label' => 'Show button in question lists',
+                        'type' => 'checkbox',
+                        'value' => (bool) qa_opt('mobbr_support_show_button_in_lists'),
+                        'tags' => 'name="mobbr_support_show_button_in_lists_field"',
                     ),
                     array(
                         'label' => 'Button widget:',

--- a/qa-mobbr-admin.php
+++ b/qa-mobbr-admin.php
@@ -111,6 +111,7 @@
                     array(
                         'label' => 'Button widget:',
                         'type' => 'textarea',
+                        'rows' => 3,
                         'value' => qa_opt('mobbr_support_button_html') ? qa_opt('mobbr_support_button_html') : '{{button}}',
                         'tags' => 'name="mobbr_support_button_html_field"',
                         'note' => '<small>HTML that will be added inline to the page, {{button}} is the placeholder for the button and should always be here</small>',

--- a/qa-mobbr-frontend.php
+++ b/qa-mobbr-frontend.php
@@ -21,7 +21,6 @@
 
     }
 
-
 /*
 	Omit PHP closing tag to help avoid accidental output
 */

--- a/qa-mobbr-frontend.php
+++ b/qa-mobbr-frontend.php
@@ -1,0 +1,26 @@
+<?php
+
+    class qa_mobbr_frontend {
+
+        static function get_html_button()
+        {
+            require_once 'qa-mobbr.php';
+
+            $buttontype = qa_mobbr::$buttontypes[qa_opt('mobbr_support_buttontype')];
+            $currency = qa_opt('mobbr_support_currency');
+            $buttonhtml = '<script type="text/javascript">mobbr.button' . $buttontype. '(' . '"", "' . $currency . '");</script>';
+            $html = qa_opt('mobbr_support_button_html');
+            if (strpos($html, '{{button}}')) {
+                $html = str_replace('{{button}}', $buttonhtml, $html);
+            } else {
+                $html = $buttonhtml;
+            }
+            return $html;
+        }
+
+    }
+
+
+/*
+	Omit PHP closing tag to help avoid accidental output
+*/

--- a/qa-mobbr-frontend.php
+++ b/qa-mobbr-frontend.php
@@ -2,13 +2,14 @@
 
     class qa_mobbr_frontend {
 
-        static function get_html_button()
+        static function get_html_button($questionid = null)
         {
             require_once 'qa-mobbr.php';
 
             $buttontype = qa_mobbr::$buttontypes[qa_opt('mobbr_support_buttontype')];
             $currency = qa_opt('mobbr_support_currency');
-            $buttonhtml = '<script type="text/javascript">mobbr.button' . $buttontype. '(' . '"", "' . $currency . '");</script>';
+            $url = isset($questionid) ? qa_q_path($questionid, '', true) : '';
+            $buttonhtml = sprintf('<script type="text/javascript">mobbr.button%s("%s", "%s");</script>', $buttontype, $url, $currency);
             $html = qa_opt('mobbr_support_button_html');
             if (strpos($html, '{{button}}')) {
                 $html = str_replace('{{button}}', $buttonhtml, $html);

--- a/qa-mobbr-layer.php
+++ b/qa-mobbr-layer.php
@@ -120,7 +120,7 @@
             $meta = array(
                 "id-base" => $this->id_base(),
                 "language" => qa_opt('mobbr_support_language'),
-                "description" => "Donation to top community members, based on the points the earned.", 
+                "description" => "Donation to top community members, based on the points the earned.",
                 "keywords" => array("qa", "question2answer"));
             $meta['participants'] = array();
             $platform_percentage = qa_opt('mobbr_support_platform_percentage');

--- a/qa-mobbr-layer.php
+++ b/qa-mobbr-layer.php
@@ -233,7 +233,9 @@
         {
             require_once QA_HTML_THEME_LAYER_DIRECTORY . 'qa-mobbr-frontend.php';
 
-            $this->output(qa_mobbr_frontend::get_html_button());
+            if (qa_opt('mobbr_support_show_button_in_lists')) {
+                $this->output(qa_mobbr_frontend::get_html_button());
+            }
             parent::q_item_main($q_item);
         }
 

--- a/qa-mobbr-layer.php
+++ b/qa-mobbr-layer.php
@@ -226,6 +226,17 @@
                 //$this->output('<meta name="participation" content=\''.json_encode($meta).'\'/>');
             }
         }
+
+        // Q2A layer function
+
+        public function q_item_main($q_item)
+        {
+            require_once QA_HTML_THEME_LAYER_DIRECTORY . 'qa-mobbr-frontend.php';
+
+            $this->output(qa_mobbr_frontend::get_html_button());
+            parent::q_item_main($q_item);
+        }
+
 	}
 
 

--- a/qa-mobbr-layer.php
+++ b/qa-mobbr-layer.php
@@ -233,8 +233,8 @@
         {
             require_once QA_HTML_THEME_LAYER_DIRECTORY . 'qa-mobbr-frontend.php';
 
-            if (qa_opt('mobbr_support_show_button_in_lists')) {
-                $this->output(qa_mobbr_frontend::get_html_button());
+            if (qa_opt('mobbr_support_show_button_in_lists') && isset($q_item['raw']['postid'])) {
+                $this->output(qa_mobbr_frontend::get_html_button($q_item['raw']['postid']));
             }
             parent::q_item_main($q_item);
         }

--- a/qa-mobbr-widget-button.php
+++ b/qa-mobbr-widget-button.php
@@ -25,20 +25,9 @@
 
         function output_widget($region, $place, $themeobject, $template, $request, $qa_content)
         {
-            require_once 'qa-mobbr.php';
-            require_once 'qa-mobbr-url.php';
-            require_once 'qa-mobbr-layer.php';
+            require_once 'qa-mobbr-frontend.php';
 
-            $buttontype = qa_mobbr::$buttontypes[qa_opt('mobbr_support_buttontype')];
-            $currency = qa_opt('mobbr_support_currency');
-            $buttonhtml = '<script type="text/javascript">mobbr.button' . $buttontype. '(' . '"", "' . $currency . '");</script>';
-            $html = qa_opt('mobbr_support_button_html');
-            if (strpos($html, '{{button}}')) {
-                $html = str_replace('{{button}}', $buttonhtml, $html);
-            } else {
-                $html = $buttonhtml;
-            }
-            $themeobject->output($html );
+            $themeobject->output(qa_mobbr_frontend::get_html_button());
         }
     }
 


### PR DESCRIPTION
This should get the job done without requiring the Q2A core to be modified as requested here https://github.com/q2a/question2answer/issues/157.

The branch is actually untested as I don't know anything about mobbr. However, I haven't made any change in the logic so it should work the same as before.

It is important to note that the button has to be customized per theme, as I explained in the linked ticket. In case of the SnowFlat (Q2A v1.7) theme it seems to be working without any code change:

![mobbr1](https://cloud.githubusercontent.com/assets/1449790/5294260/1d7f1108-7b61-11e4-974b-3acaff1da411.png)

In case of the Snow (Q2A v1.6) theme I had to add this CSS fix:

``` css
.qa-q-item-main {
    width: 440px;
}
```

![mobbr-2](https://cloud.githubusercontent.com/assets/1449790/5294269/491a38ba-7b61-11e4-8aa0-ef4594788436.png)
